### PR TITLE
Update dependencies to v4.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pycares" %}
-{% set version = "3.1.1" %}
+{% set version = "4.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 18dfd4fd300f570d6c4536c1d987b7b7673b2a9d14346592c5d6ed716df0d104
+  sha256: d0154fc5753b088758fbec9bc137e1b24bb84fc0c6a09725c8bac25a342311cd
 
 build:
   number: 0
@@ -24,6 +24,7 @@ requirements:
   run:
     - python
     - cffi >=1.5.0
+    - idna >=2.1
 
 test:
   imports:


### PR DESCRIPTION
<!--
Please add any other relevant info below:
-->
It's a dependency of aiodns v3.0.0



Category:  other
Popularity: 
Branch: v4.0.0
Version change: bump version number from 3.1.1 to v4.0.0
Update branch: https://github.com/AnacondaRecipes/pycares-feedstock/blob/v4.0.0/recipe/meta.yaml
license: MIT
Release date: May 14, 2021, https://pypi.org/project/pycares/#history
Changelog: significant changes https://github.com/saghul/pycares/blob/master/ChangeLog
dev_url:  https://github.com/saghul/pycares
Bug Tracker: new open issues https://github.com/saghul/pycares/issues
Github releases:  https://github.com/saghul/pycares/releases
Github license:  https://github.com/saghul/pycares/blob/master/LICENSE
Upstream setup.py:  https://github.com/saghul/pycares/blob/master/setup.py
Concourse builds correctly

Result:
- all-succeeded
